### PR TITLE
Use immutable URLs for assets and install a ServiceWorker.

### DIFF
--- a/contents/css/_components.arrow-block.css
+++ b/contents/css/_components.arrow-block.css
@@ -1,7 +1,7 @@
 .c-arrow-block {
   padding-top: 4rem;
   padding-bottom: 4rem;
-  background-image: url('../svg/index-arrow.svg');
+  background-image: url('contents:svg/index-arrow.svg');
   background-position: center;
   background-repeat: no-repeat;
   background-size: 300%;

--- a/contents/css/_components.nav-main-toggle.css
+++ b/contents/css/_components.nav-main-toggle.css
@@ -1,5 +1,5 @@
 .c-nav-main-toggle {
-  background: url("../svg/hamburger.svg") center center;
+  background: url("contents:svg/hamburger.svg") center center;
   background-size: cover;
   border: 0;
   color: var(--c-white);
@@ -12,5 +12,5 @@
 }
 
 .is-nav-opened .c-nav-main-toggle {
-  background-image: url("../svg/close.svg");
+  background-image: url("contents:svg/close.svg");
 }

--- a/contents/css/_components.stage.css
+++ b/contents/css/_components.stage.css
@@ -3,7 +3,7 @@
   padding-bottom: calc(var(--l-gutter) * 2);
   padding-top: calc(var(--l-gutter) * 2);
   margin-bottom: 18rem;
-  background-image: url(../images/home-pattern.svg);
+  background-image: url(contents:images/home-pattern.svg);
   background-size: 210%;
   height: 826px;
   border-bottom: 7px solid #191919;
@@ -120,7 +120,7 @@
 
 .c-stage--picture {
   --stage-content-margin-top: 30vh;
-  background-image: url(../images/home-stage-small.jpg);
+  background-image: url(contents:images/home-stage-small.jpg);
   background-position: center center;
   background-size: cover;
   height: 50vh;
@@ -129,7 +129,7 @@
     margin-bottom: 34rem;
   }
   @media (--m) {
-    background-image: url(../images/home-stage.jpg);
+    background-image: url(contents:images/home-stage.jpg);
     margin-bottom: 28rem;
   }
   .c-stage__content {

--- a/contents/css/_settings.typography.css
+++ b/contents/css/_settings.typography.css
@@ -1,19 +1,19 @@
 @font-face {
   font-family: "GT Walsheim Pro Regular";
   font-display: swap;
-  src: url('../fonts/GT-Walsheim-Regular.eot');
-  src: url('../fonts/GT-Walsheim-Regular.eot?#iefix') format('embedded-opentype'),
-       url('../fonts/GT-Walsheim-Regular.woff') format('woff'),
-       url('../fonts/GT-Walsheim-Regular.ttf') format('truetype');
+  src: url('contents:fonts/GT-Walsheim-Regular.eot');
+  src: url('contents:fonts/GT-Walsheim-Regular.eot') format('embedded-opentype'),
+       url('contents:fonts/GT-Walsheim-Regular.woff') format('woff'),
+       url('contents:fonts/GT-Walsheim-Regular.ttf') format('truetype');
 }
 
 @font-face {
   font-family: "GT Walsheim Pro Medium";
   font-display: swap;
-  src: url('../fonts/GT-Walsheim-Medium.eot');
-  src: url('../fonts/GT-Walsheim-Medium.eot?#iefix') format('embedded-opentype'),
-       url('../fonts/GT-Walsheim-Medium.woff') format('woff'),
-       url('../fonts/GT-Walsheim-Medium.ttf') format('truetype');
+  src: url('contents:fonts/GT-Walsheim-Medium.eot');
+  src: url('contents:fonts/GT-Walsheim-Medium.eot') format('embedded-opentype'),
+       url('contents:fonts/GT-Walsheim-Medium.woff') format('woff'),
+       url('contents:fonts/GT-Walsheim-Medium.ttf') format('truetype');
 }
 
 :root {

--- a/contents/css/splash.css
+++ b/contents/css/splash.css
@@ -24,10 +24,10 @@
 @font-face {
   font-family: "GT Walsheim Pro Regular";
   font-display: swap;
-  src: url('../fonts/GT-Walsheim-Regular.eot');
-  src: url('../fonts/GT-Walsheim-Regular.eot?#iefix') format('embedded-opentype'),
-       url('../fonts/GT-Walsheim-Regular.woff') format('woff'),
-       url('../fonts/GT-Walsheim-Regular.ttf') format('truetype');
+  src: url('contents:fonts/GT-Walsheim-Regular.eot');
+  src: url('contents:fonts/GT-Walsheim-Regular.eot?#iefix') format('embedded-opentype'),
+       url('contents:fonts/GT-Walsheim-Regular.woff') format('woff'),
+       url('contents:fonts/GT-Walsheim-Regular.ttf') format('truetype');
 }
 
 html {

--- a/contents/sw.js
+++ b/contents/sw.js
@@ -1,0 +1,41 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/3.6.1/workbox-sw.js');
+
+workbox.navigationPreload.enable();
+
+// Uncomment for debugging
+// workbox.core.setLogLevel(workbox.core.LOG_LEVELS.debug);
+
+workbox.routing.registerRoute(
+  // Cache immutable files forever
+  /\/immutable\//,
+  // Use the cache if it's available
+  workbox.strategies.cacheFirst({
+    cacheName: 'immutable-file-cache',
+  })
+);
+
+let networkTimeoutForNavigationsSeconds = 2;
+// Allow the server plenty of time to generate responses in local dev.
+if ((/localhost/.test(origin))) {
+  networkTimeoutForNavigationsSeconds = 20;
+}
+
+// Prefer the network but if it doesn't respond within 1 seconds,
+// fallback to a doc if we have a cached version that is max
+// 3 days old.
+// Basically that means that the schedule should load offline for the
+// duration of the conference.
+const navigationStrategy = workbox.strategies.networkFirst({
+  cacheName: 'nav-cache',
+  // Use the network unless things are slow
+  networkTimeoutSeconds: networkTimeoutForNavigationsSeconds,
+  plugins: [
+    new workbox.expiration.Plugin({
+      // Cache for a maximum of three days
+      maxAgeSeconds: 3 * 24 * 60 * 60,
+    })
+  ],
+});
+
+const navigationRoute = new workbox.routing.NavigationRoute(navigationStrategy, {});
+workbox.routing.registerRoute(navigationRoute);

--- a/package-lock.json
+++ b/package-lock.json
@@ -848,6 +848,11 @@
         }
       }
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -1937,6 +1942,11 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -9779,6 +9789,48 @@
         }
       }
     },
+    "postcss-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-8.0.0.tgz",
+      "integrity": "sha512-E2cbOQ5aii2zNHh8F6fk1cxls7QVFZjLPSrqvmiza8OuXLzIpErij8BDS5Y3STPfJgpIMNCPEr8JlKQWEoozUw==",
+      "requires": {
+        "mime": "^2.3.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.0",
+        "postcss": "^7.0.2",
+        "xxhashjs": "^0.2.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+        },
+        "postcss": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.6.tgz",
+          "integrity": "sha512-Nq/rNjnHFcKgCDDZYO0lNsl6YWe6U7tTy+ESN+PnLxebL8uBtYX59HZqvrj7YLK5UCyll2hqDsJOo3ndzEW8Ug==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -10955,6 +11007,14 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "requires": {
+        "cuint": "^0.2.2"
+      }
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postcss-import": "^11.0.0",
     "postcss-media-minmax": "^3.0.0",
     "postcss-nested": "^3.0.0",
+    "postcss-url": "^8.0.0",
     "prettier": "^1.10.2",
     "purify-css": "^1.2.6",
     "sharp": "^0.21.0",

--- a/plugins/nunjucks.js
+++ b/plugins/nunjucks.js
@@ -74,6 +74,18 @@ module.exports = function(env, callback) {
     }
   }
 
+  // Transform static URLs into the form:
+  // /immutable/$fileHash/filename
+  env.plugins.StaticFile.prototype.getFilename = function getFilename () {
+    // Top level files such as CNAME and manifest.json should not be renamed.
+    if (!(/\//.test(this.filepath.relative))) {
+      return this.filepath.relative;
+    }
+    const hash = require('crypto').createHash('sha1');
+    hash.update(require('fs').readFileSync(this.filepath.full), 'utf8');
+    return 'immutable/' + hash.digest('hex') + '/' + this.filepath.relative;
+  }
+
   env.registerTemplatePlugin('**/*.*(html|nunjucks|njk)', NunjucksTemplate);
   callback();
 };

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -28,7 +28,7 @@
     <meta property="og:image" content="{{ url }}{{ image }}">
   {% endblock %}
   {% include "../partials/favicon.html.njk" %}
-  <meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'">
+  <meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline'; worker-src 'self'">
   <link rel="stylesheet" href="{{ contents.css["main.css"].url }}?{{ cacheBuster }}">
   <link rel="prefetch" href="https://ti.to/cssconfeu/cssconfeu-2019/">
 </head>
@@ -48,5 +48,12 @@
   {{ contents.svg['sprite.svg'].sprite }}
 </div>
 
+<script>
+onload = function() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js');
+  }
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
With the immutable URLs all assets can be cached forever. CSS must now use the special `contents:` URLs to reference assets since URLs can no longer be guessed.

The SW caches all immutable URLs forever and provides cached HTML files from cache if the network doesn't respond within 2 seconds and the cached content is less than 3 days old.