### PR TITLE
Implement Google Docs based news and standlone article generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules
 /contents/schedule/
 /contents/speakers/
 /contents/sponsors/
+/contents/cms/
+/contents/news/
+/contents/preview/
 /contents/images/artist/
 /contents/images/speaker/
 /contents/images/sponsor/

--- a/scripts/spreadsheet-import/image-download.js
+++ b/scripts/spreadsheet-import/image-download.js
@@ -8,9 +8,11 @@ const sharp = require('sharp');
 const {promisify} = require('util');
 
 function getImageFilename(originalUrl, name, ext) {
-  let filename = name || 'image';
+  let filename = name.trim();
   filename = filename.replace(/[^\w]/g, '-');
   filename = filename.replace(/--/g, '-');
+  filename = filename.replace(/-$/g, '');
+  filename = filename.replace(/^-/g, '');
   // Filename changes if underlying URL changes.
   const hash = require('crypto').createHash('sha1')
       .update(originalUrl).digest('hex');

--- a/scripts/spreadsheet-import/index.js
+++ b/scripts/spreadsheet-import/index.js
@@ -13,6 +13,8 @@ const {downloadImage} = require('./image-download');
 
 const timeout = promisify(setTimeout);
 
+const secret = process.env.preview_filename_component || 'secret';
+
 // spreadsheet-format is illustrated here:
 //   https://docs.google.com/spreadsheets/d/14TQHTYePS0SAaXGRNF3zYXvvk8xz25CXW-uekQy4HAs/edit
 
@@ -73,6 +75,13 @@ const sheetParams = {
     dataFieldName: 'team',
     contentPath: 'team'
   },
+  articles: {
+    templateGlobals: {
+      template: 'pages/placeholder.html.njk'
+    },
+    dataFieldName: 'article',
+    contentPath: 'news'
+  },
 };
 
 const wwwtfrcFile = __dirname + '/../../.wwwtfrc';
@@ -111,21 +120,15 @@ if (!hasRcFile) {
 
 main(params).catch(err => console.error(err));
 
-async function main(params) {
-  // ---- ensure the directories exist...
-  const requiredDirectories = ['artists', 'schedule', 'speakers', 'sponsors', 'talks', 'team', 'images/artist', 'images/speaker', 'images/sponsor', 'images/team'];
-  const requiredDirectoryPaths = requiredDirectories.map(
-    dir => `${__dirname}/../../contents/${dir}`
-  );
-  const missingDirectories = requiredDirectoryPaths.filter(
-    dir => !fs.existsSync(dir)
-  );
-
-  if (!!missingDirectories.length) {
-    console.log(chalk.gray('creating missing directories...'));
-    missingDirectories.forEach(dir => mkdirp(dir));
+function ensureDirExists(dir) {
+  const fullDir = `${__dirname}/../../contents/${dir}`;
+  if (fs.existsSync(fullDir)) {
+    return;
   }
+  mkdirp(fullDir);
+}
 
+async function main(params) {
   // ---- cleanup...
   if (params.doCleanup) {
     console.log(chalk.gray('cleaning up...'));
@@ -157,7 +160,9 @@ async function main(params) {
 
   // ---- parse and generate markdown-files
   console.log(chalk.gray('awesome, that worked.'));
-  Object.keys(sheets).forEach(sheetId => {
+  const previewFiles = [];
+  const processedRecords = [];
+  Object.keys(sheets).map(async function(sheetId) {
     if (!sheetId) {
       // Published pages create unnamed sheets.
       return;
@@ -167,18 +172,14 @@ async function main(params) {
       return;
     }
     const {templateGlobals, dataFieldName, contentPath} = sheetParams[sheetId];
+    ensureDirExists(contentPath);
     const records = processSheet(sheets[sheetId]);
 
     console.log(chalk.white('processing sheet %s'), chalk.yellow(sheetId));
-    records
-      // filter unpublished records when not in dev-mode.
-      .filter(r => r.published || !params.publishedOnly)
-      // render md-files
-      .forEach(async function(record) {
-        const filename = path.join(contentRoot, contentPath, `${record.id}.md`);
-
-        const {content = '', ...data} = record;
-        let title = '';
+    processedRecords.push.apply(processedRecords, records
+      .map(async function(record) {
+        let {content = '', ...data} = record;
+        let title = data.name;
 
         if (sheetId === 'speakers') {
           title = `${data.name}: ${data.talkTitle}`;
@@ -195,22 +196,48 @@ async function main(params) {
         let imageExtension = null;
         if (sheetId === 'sponsors') {
           imageExtension = 'svg';
-          title = `${data.name}`;
         }
         const imageUrl = data.potraitImageUrl || data.logoUrl;
         data.image = await downloadImage(imageUrl, title, imageExtension);
 
-        const frontmatter = yaml.safeDump({
+        const extracted = extractFrontmatter(data, content);
+        let frontmatterFromContent = {};
+        if (extracted) {
+          content = extracted.content;
+          frontmatterFromContent = extracted.frontmatter;
+        }
+        const metadata = {
           ...templateGlobals,
           title,
+          ...frontmatterFromContent,
           [dataFieldName]: data
-        });
+        };
+
+        let cpath = contentPath;
+        if (metadata.standalone) {
+          cpath = 'cms';
+          ensureDirExists(cpath);
+        }
+
+        let filename = getFilename(title);
+        if (!data.published && params.publishedOnly) {
+          metadata.filename = ':file.html';
+          cpath = 'preview';
+          ensureDirExists(cpath);
+          filename = `${filename}-${secret}`;
+          previewFiles.push({
+            url: `/${cpath}/${filename}.html`,
+            name: data.name,
+          });
+        }
+        const fullpath = path.join(contentRoot, cpath, `${filename}.md`);
 
         console.log(
           ' --> write markdown %s',
-          chalk.green(path.relative(process.cwd(), filename))
+          chalk.green(path.relative(process.cwd(), fullpath.replace(secret, '...')))
         );
 
+        const frontmatter = yaml.safeDump(metadata);
         try {
           const markdownContent =
             '----\n\n' +
@@ -220,11 +247,61 @@ async function main(params) {
             '\n\n----\n\n' +
             wordwrap(content || '');
 
-          fs.writeFileSync(filename, markdownContent);
+            fs.writeFile(fullpath, markdownContent, () => {/*fire and forget*/});
         } catch (err) {
           console.error('whoopsie', err);
         }
-      });
+      }));
   });
+  await Promise.all(processedRecords);
+  ensureDirExists('preview');
+  fs.writeFileSync(`${contentRoot}/preview/${secret}.md`,
+      '----\n\ntemplate: pages/simple.html.njk\n' +
+      'filename: :file.html\n\n----\n\n' +
+      previewFiles.map(file => {
+        return `<a href="${file.url}">${file.name}</a>`;
+      }).join('<br>\n'));
 }
 
+function extractFrontmatter(data, content) {
+  let frontmatterFromContent;
+  if (!content.startsWith('----\n')) {
+    return;
+  }
+  let sepCount = 0;
+  let yamlString = '';
+  let rest = ''
+  content.split('\n').forEach(line => {
+    if (line == '----') {
+      sepCount++;
+      return;
+    }
+    if (sepCount >= 2) {
+      rest += line + '\n';
+      return;
+    }
+    yamlString += line + '\n';
+  });
+  if (sepCount != 2) {
+    console.log(chalk.red('Incomplete frontmatter in'), data.name);
+    return;
+  }
+  try {
+    return {
+      frontmatter: yaml.safeLoad(yamlString),
+      content: rest,
+    };
+  } catch (e) {
+    console.log(chalk.red('Invalid frontmatter in'), data.name, e.message);
+    return;
+  }
+}
+
+function getFilename(name) {
+  let filename = name.trim();
+  filename = filename.replace(/[^\w]/g, '-');
+  filename = filename.replace(/--/g, '-');
+  filename = filename.replace(/-$/g, '');
+  filename = filename.replace(/^-/g, '');
+  return filename.toLowerCase();
+}

--- a/templates/pages/simple.html.njk
+++ b/templates/pages/simple.html.njk
@@ -1,0 +1,21 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% from "../_macros.njk" import pageIntro %}
+
+{% block content %}
+  {{
+    pageIntro(
+      data.metadata.title,
+      data.metadata.introText,
+      contents.images.intros[data.metadata.introImage]
+    )
+  }}
+
+  <div class="l-container">
+    <main>
+      <div class="c-markdown c-markdown--indented-paragraphs">
+        {{ page.html }}
+      </div>
+    </main>
+  </div>
+{% endblock %}


### PR DESCRIPTION
New features

- By default Google Docs from the fight folder are written to the news collection.
- If the doc has a `standalone` field in the frontmatter, the article is written to the `cms` directory instead. The actual URL is defined by the `filename` frontmatter.
- If the doc isn't `published` in the spreadsheet docs are written to a preview directory with unguessable filename.

Please note, that this doesn't actually show the "news" anywhere.

TODO: Set new env var in travis: `preview_filename_component`