### PR TITLE
Add BIPoCiT Speakers page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /contents/artists/
 /contents/schedule/
 /contents/speakers/
+/contents/bipocit-space/
 /contents/sponsors/
 /contents/cms/
 /contents/news/

--- a/contents/bipocit-space-speakers.json
+++ b/contents/bipocit-space-speakers.json
@@ -1,0 +1,5 @@
+{
+  "filename": "/bipocit-space/speakers/index.html",
+  "template": "pages/bipocit-space-speakers.html.njk",
+  "title": "BIPoCiT Speakers"
+}

--- a/scripts/spreadsheet-import/index.js
+++ b/scripts/spreadsheet-import/index.js
@@ -64,6 +64,13 @@ const sheetParams = {
     dataFieldName: 'speaker',
     contentPath: 'speakers'
   },
+  'bipocit-speakers': {
+    templateGlobals: {
+      template: 'pages/speaker.html.njk'
+    },
+    dataFieldName: 'speaker',
+    contentPath: 'bipocit-space/speakers'
+  },
   sponsors: {
     templateGlobals: {},
     dataFieldName: 'sponsor',

--- a/templates/pages/bipocit-space-speakers.html.njk
+++ b/templates/pages/bipocit-space-speakers.html.njk
@@ -1,0 +1,41 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% from "../_macros.njk" import pageIntro %}
+
+{% block content %}
+  {{ pageIntro(page.title) }}
+
+  <div class="l-container">
+    <main>
+      {% set speakers = contents['bipocit-space'].speakers._.pages
+        | filterObjects('metadata.speaker.reviewed', true)
+        | filterObjects('metadata.speaker.published', true) %}
+
+      {% if speakers.length %}
+        <div class="c-artists-gallery">
+          {% for speaker in speakers %}
+            {% set speakerData = speaker.metadata.speaker %}
+            <div class="c-artists-gallery__item">
+              <a class="c-artists-gallery__artist" href="{{ speaker.url }}">
+                <div class="c-artists-gallery__image">
+                  <img
+                    src="{{ contents.images.cms[speakerData.image.filename_500].url }}"
+                    alt="{{ speakerData.name }}"
+                  />
+                </div>
+                <div class="c-artists-gallery__name fz--gamma">
+                  {% set name = speakerData.name | splitString(' ') %}
+                  {{ name | first }}<br>{{ name | last }}
+                </div>
+              </a>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </main>
+  </div>
+{% endblock %}
+
+{% block footer %}
+  {% include "../partials/footer.html.njk" %}
+{% endblock %}


### PR DESCRIPTION
Links:

Speakers list: `https://2019.cssconf.eu/bipocit-space/speakers/` (will follow the same layout as the Artists page)
Speaker details page: `https://2019.cssconf.eu/bipocit-space/speakers/speaker-name/`

Preview:

![localhost_8888_bipocit-space_speakers_](https://user-images.githubusercontent.com/11782/57334210-62619d00-711f-11e9-8fa2-f64ef56609ca.png)